### PR TITLE
CIP-6: Removed source outputs from examples

### DIFF
--- a/cip-0006.md
+++ b/cip-0006.md
@@ -2,10 +2,11 @@
   CIP: 6
   Title: P2SH data encoding; at least it's not P2PKH
   Authors: Ruben de Vries
-  Discussions-To:
+  Discussions-To: https://counterpartytalk.org/t/cip-proposal-p2sh-data-encoding/2169/22
   Status: Draft
   Type: Standards
   Created: 2016-06-24
+  Updated: 2017-11-16
 </pre>
 
 
@@ -24,19 +25,16 @@ Counterparty currently has the following data encoding schemes:
 For (literally) 99% of Counterparty transactions `opreturn` is enough (though some people forcefully use multisig encoding).
 Previously for the rest we'd fall back to using `multisig` encoding since it has no real drawbacks.
 
-Unfortunately since Bitcoin Core v0.12.1 there's a DoS protection (called `bytespersigop`) that has essentially made bare multisig non-standard.
+In Bitcoin Core v0.12.1 there was a DoS protection (called `bytespersigop`) that essentially made bare multisig non-standard.  Bare multisig is discouraged by Bitcoin Core developers and may likely be limited or removed in a future Bitcoin Core release.
 
 So we need an alternative for larger amounts of data and we want to avoid `pubkeyhash` encoding because it pollutes the UTXO set too much.
-
-With the EVM coming there will also be more transactions with larger amounts of data, so we need this more than ever!
-
 
 ## Rationale ##
 
 It's possible to embed data in P2SH redeemScripts by doing 2 transactions
 where the first one sets up P2SH outputs with redeemScripts that allow us to put the data in the scriptSig of the spending transaction.
 
-With this method we can easily put in a lot more data than the other methods, does not polute the UTXO set
+With this method we can easily put in a lot more data than the other methods.  This does not polute the UTXO set
 and signature data can be pruned by Bitcoin nodes that wish to do so.
 
 The original proof of concept, by Peter Todd, of this can be found here: https://github.com/petertodd/python-bitcoinlib/blob/master/examples/publish-text.py
@@ -92,37 +90,32 @@ Below we'll describe how a Counterparty `send` would look.
  - 1 + n UTXOs from the `source` address to have enough BTC to pay the fees for both the first and the second transaction.
 
 ###### Outputs
- - 1 output to `source` with enough value to pay the fee for the second transaction.
- - 1 + n P2SH outputs following the above method with `DUST` value.
+ - 1 + n P2SH outputs following the above method with at least `DUST` value.  The sum of these outputs must contain enough value to pay the fees for the second transaction.
  - 1 change output to send any excess BTC back to `source` (optional; but in practice always there)
 
 ##### Transaction 2
 
 ###### Inputs
- - 1 input spending the `source` output from Transaction 1
- - 1 + n inputs spending the P2SH outputs, including the data in the `scriptSig`
+ - 1 + n inputs spending the P2SH outputs.  The transaction data is included in the `scriptSig`
 
 ###### Outputs
- - 1 output to specify the destination of the Counterparty transaction (in some types of transactions this is omitted) with `DUST` value.
+ - 1 output to specify the destination of the Counterparty transaction with `DUST` value if needed.  In most types of transactions this can be omitted.
  - 1 `opreturn` output encoding the data `'CNTRPTY' + 'P2SH'` to signal that the data is found in the P2SH inputs, with 0 value.
 
 ###### Fees & Coin Selection
-The first transaction has send enough BTC to the second transaction so the second transaction can pay for it's own fee without having to add extra inputs.
-So we calculate the value of the `source` output in the first transaction to be:
+The first transaction has to send enough BTC to the second transaction so the second transaction can pay for it's own fee without having to add extra inputs.
+So we calculate the value of the output in the first transaction to be:
 ```
 estimated_size_of_tx2 = 10  # base size of  TX
 estimated_size_of_tx2 += 181  # for source input
-estimated_size_of_tx2 += 29 * count(destination_outputs)  # for destination outputs
 estimated_size_of_tx2 += sizeof(data)  # for the data
 estimated_size_of_tx2 += count(data_p2sh_outputs) * (181 + 9)  # for the overhead of each data output being spend
 estimated_fee_for_tx2 = (estimated_size_of_tx2 / 1000) * fee_per_kb
-source_output_value = count(data_p2sh_outputs) * DUST + count(destination_outputs) * DUST + estimated_fee_for_tx2
 ```
 
 This means the amount of BTC to require when doing coinselection is:
 ```
 estimated_size_of_tx1_without_inputs = 10  # base size of a TX
-estimated_size_of_tx1_without_inputs += 29  # for source output
 estimated_size_of_tx1_without_inputs += count(data_p2sh_outputs) * 29  # for P2SH data outputs
 
 inputs = []
@@ -131,7 +124,7 @@ for UTXO in coinselection:
    estimated_size_of_tx1 = estimated_size_of_tx1_without_inputs + count(inputs) * 181
    estimated_fee_for_tx1 = (estimated_size_of_tx1 / 1000) * fee_per_kb
 
-   if sum(inputs) >= estimated_fee_for_tx1 + estimated_fee_for_tx2 + source_output_value + count(data_p2sh_outputs) * DUST:
+   if sum(inputs) >= estimated_fee_for_tx1 + estimated_fee_for_tx2:
        break
 ```
 
@@ -140,11 +133,11 @@ In practice this means the `create_*` API calls will have to start returning a l
 so clients need to adapt to this new style and always assume they need to sign and broadcast N transactions.
 
 Pre-segwit we won't be able to have the second transaction spend from the first transaction until the first transaction has been signed,
-this means the client actually needs to do 2 API calls, where the second has the txId of the signed first transaction as param.
+this means the client actually needs to do 2 API calls, where the second has the txId of the signed first transaction as a parameter.
 
 Once we can use segwit this problem is gone! However not all clients will straight away be able to sign segwit transactions (requires upgrades of the libraries they use).
 
-Because of this being quite a hassle we propose to have 2 node configs / API params to control all of this: `segwit` and `old_style_api`.
+Because of this being quite a hassle we propose to have 2 configuration and API parameters to control all of this: `segwit` and `old_style_api`.
 
 ##### `old_style_api`
 When `old_style_api = True` the API will continue to function as normal, returning a single transaction, as string.
@@ -159,10 +152,6 @@ which should be the txId of the signed first transaction.
 The second API call will then return `[None, tx_hex]`.
 
 When `segwit = True` the API call will return `[tx_hex, tx_hex]` and will no longer require a second API call.
-
-##### EVM Transactions
-Because the nature of EVM transactions being large(r) amounts of data,
-the EVM API calls (`create_publish` and `create_broadcast`) will require `old_style_api == False`.
 
 
 ### Child pays for Parent

--- a/cip-0006.md
+++ b/cip-0006.md
@@ -87,20 +87,23 @@ Below we'll describe how a Counterparty `send` would look.
 ##### Transaction 1
 
 ###### Inputs
- - 1 + n UTXOs from the `source` address to have enough BTC to pay the fees for both the first and the second transaction.
+ - 1 + n UTXOs from any address with enough BTC to pay the fees for both the first and the second transaction.
 
 ###### Outputs
  - 1 + n P2SH outputs following the above method with at least `DUST` value.  The sum of these outputs must contain enough value to pay the fees for the second transaction.
- - 1 change output to send any excess BTC back to `source` (optional; but in practice always there)
+ - 1 change output to send any excess BTC to any address (optional; but in practice always there)
 
 ##### Transaction 2
 
 ###### Inputs
+ - 1 input spending a source output from the `source`.  (This is optional.  It can be used for determining a P2SH source.  See below.)
  - 1 + n inputs spending the P2SH outputs.  The transaction data is included in the `scriptSig`
 
 ###### Outputs
- - 1 output to specify the destination of the Counterparty transaction with `DUST` value if needed.  In most types of transactions this can be omitted.
+ - 1 output to specify the destination of the Counterparty transaction with `DUST` value if needed.  In most transactions this can be omitted.
  - 1 `opreturn` output encoding the data `'CNTRPTY' + 'P2SH'` to signal that the data is found in the P2SH inputs, with 0 value.
+ - 1 optional change output to any address (optional)
+
 
 ###### Fees & Coin Selection
 The first transaction has to send enough BTC to the second transaction so the second transaction can pay for it's own fee without having to add extra inputs.
@@ -127,6 +130,87 @@ for UTXO in coinselection:
    if sum(inputs) >= estimated_fee_for_tx1 + estimated_fee_for_tx2:
        break
 ```
+
+
+### Determining the source address
+
+If the redeem script contains `{{ pubkey }} OP_CHECKSIGVERIFY`, then the source address will be constructed from the pubkey provided in the redeem script.
+
+When the source address is a P2SH address, the redeem script will not contain any pubkey.  In this case, the source address must be determined with another input.  If transaction 2 spends an input from a P2SH script and there is no `{{ pubkey }} OP_CHECKSIGVERIFY` in the redeem script, then the source address will be the P2SH address that provided the first input in transaction 2.
+
+
+### Example 1: A standard (P2PKH) address
+
+Say we have source address of `1aP2PKHaddressxxxxxxxxxxxxxy43CZ9j` and a data script hash of `3aP2SHDataAddress001xxxxxxxy4zdFf3`.
+
+**Transaction 1 Input:**
+
+Input  | Value     
+------ | ------
+1      | 0.100
+
+**Transaction 1 Outputs:**
+
+Output | Value  | Destination                        | Note
+------ | ------ | ---------------------------------- | ---------------------
+1      | 0.001  | 3aP2SHDataAddress001xxxxxxxy4zdFf3 | Fund Transaction 2
+2      | 0.098  | 1aP2PKHaddressxxxxxxxxxxxxxy43CZ9j | Change (optional)
+
+_Fee Paid: 0.001_
+
+
+**Transaction 2 Input:**
+
+Input  | Value  | Paid to                            | ScriptSig
+------ | ------ | ---------------------------------- | --------------------------------------------------------
+1      | 0.001  | 3aP2SHDataAddress001xxxxxxxy4zdFf3 | `<signature> {{ data }} OP_HASH160 {{ hash160(data) }} OP_EQUALVERIFY {{ pubkey }} OP_CHECKSIGVERIFY {{ n }} OP_DROP OP_DEPTH 0 OP_EQUAL`
+
+**Transaction 2 Output:**
+
+Output | Value  | Destination  | Note
+------ | ------ | ------------ | ------------------------------------------------
+1      | 0      | OP_RETURN    | `CNTRPTYP2SH`
+
+_Fee Paid: 0.001_
+
+
+### Example 2: A multisig (P2SH) address
+
+Say we have a source address that is a 2-of-3 multisig address with an address of `3aMultisigAddressxxxxxxxxxxy1QHYVH` and a data script hash of `3aP2SHDataAddress002xxxxxxxy4zdFf3`.
+
+**Transaction 1 Input:**
+
+Input  | Value     
+------ | ------
+1      | 0.100
+
+**Transaction 1 Outputs:**
+
+Output | Value  | Destination                        | Note
+------ | ------ | ---------------------------------- | ---------------------
+1      | 0.001  | 3aP2SHDataAddress002xxxxxxxy4zdFf3 | funds transaction 2
+2      | 0.098  | 3aMultisigAddressxxxxxxxxxxy1QHYVH | change (optional)
+
+_Fee Paid: 0.001_
+
+
+**Transaction 2 Inputs:**
+
+Input  | Value  | Paid to                            | ScriptSig
+------ | ------ | ---------------------------------- | --------------------------------------------------------
+1      | 0.098  | 3aMultisigAddressxxxxxxxxxxy1QHYVH | `0 <signature1> <signature2> 2 {{ pubkey1 }} {{ pubkey2 }} {{ pubkey3 }} 3 OP_CHECKMULTISIG`
+2      | 0.001  | 3aP2SHDataAddress002xxxxxxxy4zdFf3 | `0 <signature1> <signature2> {{ data }} OP_HASH160 {{ hash160(data) }} OP_EQUALVERIFY 2 {{ pubkey1 }} {{ pubkey2 }} {{ pubkey3 }} 3 OP_CHECKMULTISIGVERIFY {{ n }} OP_DROP OP_DEPTH 0 OP_EQUAL`
+
+**Transaction 2 Outputs:**
+
+Output | Value  | Destination                        | Note
+------ | ------ | ---------------------------------- | ------------------------------------------------
+1      | 0      | OP_RETURN                          | `CNTRPTYP2SH`
+2      | 0.098  | 3aMultisigAddressxxxxxxxxxxy1QHYVH | change (optional)
+
+_Fee Paid: 0.001_
+
+
 
 ### The Counterparty API
 In practice this means the `create_*` API calls will have to start returning a list of 1 or more transactions which the client signs and broadcasts,

--- a/cip-0006.md
+++ b/cip-0006.md
@@ -46,7 +46,7 @@ The original proof of concept, by Peter Todd, of this can be found here: https:/
 This process requires 2 transactions, the first to setup 1 or more P2SH outputs and then the second spending the P2SH outputs and placing the data we wish to embed in the `scriptSig`.
 
 ##### The Redeem Script
-The data is split chunks of max X size, then for each chunk we create a `redeemScript` as follows:
+The data is split into chunks of max 520 size, then for each chunk we create a `redeemScript` as follows:
 
 ```
 redeemScript = {{ data }} OP_HASH160 {{ hash160(data) }} OP_EQUALVERIFY {{ pubkey }} OP_CHECKSIGVERIFY {{ n }} OP_DROP OP_DEPTH 0 OP_EQUAL
@@ -136,7 +136,7 @@ for UTXO in coinselection:
 
 If the redeem script contains `{{ pubkey }} OP_CHECKSIGVERIFY`, then the source address will be constructed from the pubkey provided in the redeem script.
 
-When the source address is a P2SH address, the redeem script will not contain any pubkey.  In this case, the source address must be determined with another input.  If transaction 2 spends an input from a P2SH script and there is no `{{ pubkey }} OP_CHECKSIGVERIFY` in the redeem script, then the source address will be the P2SH address that provided the first input in transaction 2.
+When the source address is a P2SH address, the redeem script will not contain any pubkey.  In this case, the source address will be determined by the first input.  If transaction 2 spends an input from a P2SH script and there is no `{{ pubkey }} OP_CHECKSIGVERIFY` in the redeem script, then the source address will be the P2SH address that provided the first input spent in transaction 2.
 
 
 ### Example 1: A standard (P2PKH) address

--- a/cip-0006.md
+++ b/cip-0006.md
@@ -49,20 +49,20 @@ This process requires 2 transactions, the first to setup 1 or more P2SH outputs 
 The data is split into chunks of max 520 size, then for each chunk we create a `redeemScript` as follows:
 
 ```
-redeemScript = {{ data }} OP_HASH160 {{ hash160(data) }} OP_EQUALVERIFY {{ pubkey }} OP_CHECKSIGVERIFY {{ n }} OP_DROP OP_DEPTH 0 OP_EQUAL
+redeemScript = {{ data }} OP_DROP {{ pubkey }} OP_CHECKSIGVERIFY {{ n }} OP_DROP OP_DEPTH 0 OP_EQUAL
 ```
 
 dissecting this into pieces we have:
 
 ```
-{{ data }} OP_HASH160 {{ hash160(data) }} OP_EQUALVERIFY
+{{ data }}
 ```
-this is where we place the data and the `OP_HASH160 {{ hash160(data) }} OP_EQUALVERIFY` ensure the data can't be changed.
+this is the counterparty operation data.  Since this data is part of the redeemScript it is included in the hash of the P2SH address.
 
 ```
 {{ pubkey }} OP_CHECKSIGVERIFY
 ```
-this ensures the output needs to be signed by the owner, this can be replaced by other scripts such as a multisig or CLTV or similar things that were previously already put into P2SH outputs.
+this ensures the output needs to be signed by the owner. Any arbitrary script operation is allowed here as well.
 
 ```
 {{ n }} OP_DROP
@@ -91,18 +91,18 @@ Below we'll describe how a Counterparty `send` would look.
 
 ###### Outputs
  - 1 + n P2SH outputs following the above method with at least `DUST` value.  The sum of these outputs must contain enough value to pay the fees for the second transaction.
- - 1 change output to send any excess BTC to any address (optional; but in practice always there)
+ - 1 change output to send any excess BTC to the sender or a new change address.  This is optional.
 
 ##### Transaction 2
 
 ###### Inputs
- - 1 input spending a source output from the `source`.  (This is optional.  It can be used for determining a P2SH source.  See below.)
- - 1 + n inputs spending the P2SH outputs.  The transaction data is included in the `scriptSig`
+ - 1 input spending a source output from the `source`.  (This is optional.  It can be used for defining a source address when sending from a P2SH address.  See below.)
+ - 1 + n inputs spending the P2SH data outputs.  The transaction data is included in the `scriptSig`
 
 ###### Outputs
  - 1 output to specify the destination of the Counterparty transaction with `DUST` value if needed.  In most transactions this can be omitted.
- - 1 `opreturn` output encoding the data `'CNTRPTY' + 'P2SH'` to signal that the data is found in the P2SH inputs, with 0 value.
- - 1 optional change output to any address (optional)
+ - 1 `OP_RETURN` output encoding the data `'CNTRPTY' + 'P2SH'` to signal that the data is found in the P2SH inputs, with 0 value.
+ - 1 change output to any address.  This is optional.
 
 
 ###### Fees & Coin Selection
@@ -116,7 +116,7 @@ estimated_size_of_tx2 += count(data_p2sh_outputs) * (181 + 9)  # for the overhea
 estimated_fee_for_tx2 = (estimated_size_of_tx2 / 1000) * fee_per_kb
 ```
 
-This means the amount of BTC to require when doing coinselection is:
+This means the amount of BTC to require when doing coin selection is:
 ```
 estimated_size_of_tx1_without_inputs = 10  # base size of a TX
 estimated_size_of_tx1_without_inputs += count(data_p2sh_outputs) * 29  # for P2SH data outputs
@@ -163,7 +163,7 @@ _Fee Paid: 0.001_
 
 Input  | Value  | Paid to                            | ScriptSig
 ------ | ------ | ---------------------------------- | --------------------------------------------------------
-1      | 0.001  | 3aP2SHDataAddress001xxxxxxxy4zdFf3 | `<signature> {{ data }} OP_HASH160 {{ hash160(data) }} OP_EQUALVERIFY {{ pubkey }} OP_CHECKSIGVERIFY {{ n }} OP_DROP OP_DEPTH 0 OP_EQUAL`
+1      | 0.001  | 3aP2SHDataAddress001xxxxxxxy4zdFf3 | `<signature> {{ data }} OP_DROP {{ pubkey }} OP_CHECKSIGVERIFY {{ n }} OP_DROP OP_DEPTH 0 OP_EQUAL`
 
 **Transaction 2 Output:**
 
@@ -199,7 +199,7 @@ _Fee Paid: 0.001_
 Input  | Value  | Paid to                            | ScriptSig
 ------ | ------ | ---------------------------------- | --------------------------------------------------------
 1      | 0.098  | 3aMultisigAddressxxxxxxxxxxy1QHYVH | `0 <signature1> <signature2> 2 {{ pubkey1 }} {{ pubkey2 }} {{ pubkey3 }} 3 OP_CHECKMULTISIG`
-2      | 0.001  | 3aP2SHDataAddress002xxxxxxxy4zdFf3 | `0 <signature1> <signature2> {{ data }} OP_HASH160 {{ hash160(data) }} OP_EQUALVERIFY 2 {{ pubkey1 }} {{ pubkey2 }} {{ pubkey3 }} 3 OP_CHECKMULTISIGVERIFY {{ n }} OP_DROP OP_DEPTH 0 OP_EQUAL`
+2      | 0.001  | 3aP2SHDataAddress002xxxxxxxy4zdFf3 | `0 <signature1> <signature2> {{ data }} OP_DROP 2 {{ pubkey1 }} {{ pubkey2 }} {{ pubkey3 }} 3 OP_CHECKMULTISIGVERIFY {{ n }} OP_DROP OP_DEPTH 0 OP_EQUAL`
 
 **Transaction 2 Outputs:**
 


### PR DESCRIPTION
Also:
Added discussion-to link
Clarified bytespersigop
Took out EVM language
Clarified some of the language