### PR TITLE
CIP28 - versioning, required fields, link to BTNS repo

### DIFF
--- a/cip-0028.md
+++ b/cip-0028.md
@@ -23,6 +23,8 @@ This spec can be extended in the future to allow for additional options and form
 
 This spec was inspired in part by BRC-20 and SRC-20 and seeing the desire to experiment with new token naming systems.
 
+Additional BTNS specs, indexers, and development tools are available at the official BTNS repo at: https://github.com/jdogresorg/Broadcast-Token-Naming-System
+
 # Definitions
 
 - `token` - A virtual token which was created via a `MINT` format `broadcast` transaction
@@ -39,10 +41,17 @@ In order for different projects to experiment with features in the Broadcast Tok
 
 The default BTNS prefix which should be used for BTNS transactions is `BTNS` and `BT`. All BTNS actions will begin with `btns:` or `bt:` (case insensitive)
 
+## Project Versioning
+Blockchain development moves fast, and quite often there is a need to change specs and switch to a new version immediately. The BTNS has a novel way of handling versioning, by using the `broadcast` `value` field to indicate what version of a spec a BTNS `broadcast` is using.
+
+The default BTNS version is `0` when no `broadcast` `value` is specified
+
+To specify a specific version of a BTNS spec, you can specify the version number in the `broadcast` `value` field
+
 ## `DEPLOY` format
 This format allows one to create a token and specify the following information about it
 
-- `TICK` - 1 to 5 characters in length (see rules below )
+- `TICK` - 1 to 5 characters in length (see rules below ) (required)
 - `MAX_SUPPLY` - Maximum token supply (max: 18,446,744,073,709,551,615 - commas not allowed)
 - `MAX_MINT` - Maximum amount of supply a `MINT` transaction can issue
 - `DECIMALS` - Number of decimal places token should have (max: 18, default: 0)
@@ -73,7 +82,7 @@ The above example issues a TEST token with a max supply of 100, and a maximum mi
 ### Rules
 - `broadcast` `status` must be `valid`
 - First `TICK` `DEPLOY` will be considered as valid.
-- Additional `TICK` `DEPLOY` transactions after first valid `DEPLOY` should be considered invalid and ignored.
+- Additional `TICK` `DEPLOY` transactions after first valid `TICK` `DEPLOY`, will be considered invalid and ignored, unless broadcast from `token` owners address
 - If `TICK` contains any unicode characters, then `TICK` should be `base64` encoded
 - Allowed characters in `TICK`:
    - Any word character (alphanumeric characters and underscores)
@@ -84,12 +93,12 @@ The above example issues a TEST token with a max supply of 100, and a maximum mi
 ## `MINT` format
 This format allows one to mint token supply
 
-- `TICK` - `token` name registered with `DEPLOY` format
-- `AMOUNT` - Amount of tokens to mint
-- `TRANSFER` - Address to transfer tokens to
+- `TICK` - `token` name registered with `DEPLOY` format (required)
+- `AMOUNT` - Amount of tokens to mint (required)
+- `DESTINATION` - Address to transfer tokens to
 
 **Broadcast Format:**
-`bt:MINT|TICK|AMOUNT|TRANSFER`
+`bt:MINT|TICK|AMOUNT|DESTINATION`
 
 **Example 1:**
 `bt:MINT|JDOG|1`
@@ -108,9 +117,9 @@ The above example mints 10,000,000,000,000 BRRR tokens and transfers them to 1JD
 ## `TRANSFER` format
 This format allows one to transfer or send a `token` between addresses
 
-- `TICK` - `token` name registered with `DEPLOY` format
-- `AMOUNT` - Amount of tokens to send
-- `DESTINATION` - Address to transfer tokens to
+- `TICK` - `token` name registered with `DEPLOY` format (required)
+- `AMOUNT` - Amount of tokens to send (required)
+- `DESTINATION` - Address to transfer tokens to (required)
 
 This format also allows for repeating `AMOUNT` and `DESTINATION` to enable multiple transfers in a single transaction
 


### PR DESCRIPTION
- added project versioning via broadcast `value` field
- indicated required fields in BTNS actions
- Renamed `TRANSFER` param to `DESTINATION` to remove any confusion having a BTNS Action and param named the same thing
- Added link to official BTNS github repo, where additional BTNS specs, indexers, and development tools can be found