### PR TITLE
Withdraw STAMP CIPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ Number            | Title                                      | Owner          
 [23](cip-0023.md) | Bug fixes on non-divisible dividends and 0 quantity credits | John Villar          | Standards     | Active        |
 [24](cip-0024.md) | Oracled dispensers                  | John Villar, Jeremy Johnson, & Javier Varona | Standards     | Active        |
 [25](cip-0025.md) | Enhanced Asset Information Specification   | Jeremy Johnson                        | Informational | Draft         |
-[26](cip-0026.md) | STAMP Protocol                             | MikeInSpace & Jeremy Johnson          | Informational | Draft         |
-[27](cip-0027.md) | STAMP Filesystem                           | Jeremy Johnson                        | Standards     | Draft         |
+[26](cip-0026.md) | STAMP Protocol                             | MikeInSpace & Jeremy Johnson          | Informational | Withdrawn     |
+[27](cip-0027.md) | STAMP Filesystem                           | Jeremy Johnson                        | Standards     | Withdrawn     |
 [28](cip-0028.md) | Broadcast Token Naming System              | Jeremy Johnson                        | Informational | Draft         |

--- a/cip-0026.md
+++ b/cip-0026.md
@@ -2,7 +2,7 @@
         Title: STAMP Protocol
         Author: MikeInSpace & Jeremy Johnson (J-Dog)
         Discussions-To: https://forums.counterparty.io/t/cip-26-stamp-protocol/6563
-        Status: Draft
+        Status: Withdrawn
         Type: Process
         Created: 2023-04-20
 

--- a/cip-0027.md
+++ b/cip-0027.md
@@ -2,7 +2,7 @@
         Title: STAMP Filesystem
         Author: Jeremy Johnson (J-Dog)
         Discussions-To: https://forums.counterparty.io/t/cip27-stamp-filesystem/6565
-        Status: Draft
+        Status: Withdrawn
         Type: Standards
         Created: 2023-04-20
 


### PR DESCRIPTION
- STAMPS protocol is a bad model (base64 is very inefficient)

Better solution is forthcoming CIP to encode file data directly in `issuance` and `broadcast` requests

- STAMPS Filesystem is bad model (limited view of files within “stamp” lens)

Better solution is forthcoming CIP to break off file data encoded in `issuance` and `broadcast` into optional filesystem… “stamp” file data can be grandfathered into this new system

As the author of these CIPs, I have changed the status to `Withdrawn` and would like to withdraw them from consideration as a workable CIP. 