### PR TITLE
Change status of Stamps Filesystem CIP to Withdrawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ Number            | Title                                      | Owner          
 [23](cip-0023.md) | Bug fixes on non-divisible dividends and 0 quantity credits | John Villar          | Standards     | Active        |
 [24](cip-0024.md) | Oracled dispensers                  | John Villar, Jeremy Johnson, & Javier Varona | Standards     | Active        |
 [25](cip-0025.md) | Enhanced Asset Information Specification   | Jeremy Johnson                        | Informational | Draft         |
-[26](cip-0026.md) | STAMP Protocol                             | MikeInSpace & Jeremy Johnson          | Informational | Withdrawn     |
+[26](cip-0026.md) | STAMP Protocol                             | MikeInSpace & Jeremy Johnson          | Informational | Draft         |
 [27](cip-0027.md) | STAMP Filesystem                           | Jeremy Johnson                        | Standards     | Withdrawn     |
 [28](cip-0028.md) | Broadcast Token Naming System              | Jeremy Johnson                        | Informational | Draft         |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ Number            | Title                                      | Owner          
 [23](cip-0023.md) | Bug fixes on non-divisible dividends and 0 quantity credits | John Villar          | Standards     | Active        |
 [24](cip-0024.md) | Oracled dispensers                  | John Villar, Jeremy Johnson, & Javier Varona | Standards     | Active        |
 [25](cip-0025.md) | Enhanced Asset Information Specification   | Jeremy Johnson                        | Informational | Draft         |
-[26](cip-0026.md) | STAMP Protocol                             | MikeInSpace & Jeremy Johnson          | Informational | Draft         |
-[27](cip-0027.md) | STAMP Filesystem                           | Jeremy Johnson                        | Standards     | Draft         |
+[26](cip-0026.md) | STAMP Protocol                             | MikeInSpace & Jeremy Johnson          | Informational | Withdrawn     |
+[27](cip-0027.md) | STAMP Filesystem                           | Jeremy Johnson                        | Standards     | Withdrawn     |
 [28](cip-0028.md) | Broadcast Token Naming System              | Jeremy Johnson                        | Informational | Draft         |

--- a/cip-0026.md
+++ b/cip-0026.md
@@ -2,7 +2,7 @@
         Title: STAMP Protocol
         Author: MikeInSpace & Jeremy Johnson (J-Dog)
         Discussions-To: https://forums.counterparty.io/t/cip-26-stamp-protocol/6563
-        Status: Withdrawn
+        Status: Draft
         Type: Process
         Created: 2023-04-20
 

--- a/cip-0026.md
+++ b/cip-0026.md
@@ -2,7 +2,7 @@
         Title: STAMP Protocol
         Author: MikeInSpace & Jeremy Johnson (J-Dog)
         Discussions-To: https://forums.counterparty.io/t/cip-26-stamp-protocol/6563
-        Status: Draft
+        Status: Withdrawn
         Type: Process
         Created: 2023-04-20
 

--- a/cip-0027.md
+++ b/cip-0027.md
@@ -2,7 +2,7 @@
         Title: STAMP Filesystem
         Author: Jeremy Johnson (J-Dog)
         Discussions-To: https://forums.counterparty.io/t/cip27-stamp-filesystem/6565
-        Status: Draft
+        Status: Withdrawn
         Type: Standards
         Created: 2023-04-20
 


### PR DESCRIPTION
I believe the STAMPS Filesystem CIP that I wrote is a good framework, but could be improved upon by taking a more general view of writing `file` data to the CP ledger.

Work will begin on 2 additional CIPs shortly :
- Encode file data directly in `issuance` and `broadcast` transactions via a new  `data_type` field (text, binary, hex,etc)
- Mirror Filesystem to write encoded `file` data to actual files

`stamp` file data can be grandfathered into this new system, and `stamp` file data can be migrated out of the CP database and into actual files.

I would like to Withdraw the Stamps Filesystem CIP from consideration
