### PR TITLE
Replace`raw_data` with `db_data` param

### DIFF
--- a/cip-0031.md
+++ b/cip-0031.md
@@ -32,9 +32,6 @@ The following modifications are needed to support this CIP.
 - Add new issuance data format with `data_type` field (id=22)
 - Store `data_type` info in `data_type` field in `issuances` table
 - Store `description` info in `description` field if `data_type` is `null` or `plain/text` (up to 1024 characters)
-- Add `raw_data` param to `get_issuances` API (default: false)
-- When `raw_data` param is true, retrieve issuance `description` directly from raw tx data (bitcoind)
-
 
 ## Broadcasts
 - Add `data_type` param to `create_broadcast` API (default: null)
@@ -42,8 +39,14 @@ The following modifications are needed to support this CIP.
 - Add new broadcast data format with `data_type` field (id=31)
 - Store `data_type` info in `data_type` field in `broadcasts` table
 - Store `text` info in `text` field if `data_type` is `null` or `plain/text` (up to 1024 characters)
-- Add `raw_data` param to `get_broadcast` API (default: false)
-- When `raw_data` param is true, retrieve broadcast `text` directly from raw tx data (bitcoind)
+
+## `get_{table}` API 
+- Add `db_data` param (default: `true`)
+- Set `limit` to `100` when `db_data` param is `true` (limits abuse on bitcoind)
+- `get_broadcasts`
+    - Return `text` field from raw tx data (bitcoind) when `db_data` param is `false`
+- `get_issuances`
+    - Return `description` field from raw tx data (bitcoind) when `db_data` param is `false`
 
 # Copyright
 This document is placed in the public domain.


### PR DESCRIPTION
- Replaced `raw_data` param with `db_data` param
- Added `get_{table}` API section
- Limited API results to 100 when `db_data` is false (limits bitcoind abuse)